### PR TITLE
dead-interval timer added

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,9 @@ Only the zebdra daemon is eanbled by default within the role.  To enable ospfd s
         - name: eth1
           bandwidth: 100000
           hello_timer: 5
+          dead_timer: 20
 
-The `quagga_ospfd` hash will contain the information needed configure OSPF on a host.  The `router_id` is the OSPF router-id for the host.  The `networks` key contains a list of `prefix` and `area` that will be advertised via OSPF.  The interfaces matching the given prefix will have OSPF enabled on them.  OSPF will send out hello packets and form neighbor relationships over these interfaces.  The `interfaces` key contains optional config items in a list.  The `name` is required to set either `passive` or `cost`.  The `passive` key is not required and is to allow the setting of an interface as passive.  The `bandwidth` key allows for correcting interface bandwidth, in order to have an accurate OSPF cost calculation.  This number is the interface bandwidth in kilobits per second.  The hello timer can be changed via the `hello_timer`.  The time is given in seconds, and the Quagga default is 10 seconds.
+The `quagga_ospfd` hash will contain the information needed configure OSPF on a host.  The `router_id` is the OSPF router-id for the host.  The `networks` key contains a list of `prefix` and `area` that will be advertised via OSPF.  The interfaces matching the given prefix will have OSPF enabled on them.  OSPF will send out hello packets and form neighbor relationships over these interfaces.  The `interfaces` key contains optional config items in a list.  The `name` is required to set either `passive` or `cost`.  The `passive` key is not required and is to allow the setting of an interface as passive.  The `bandwidth` key allows for correcting interface bandwidth, in order to have an accurate OSPF cost calculation.  This number is the interface bandwidth in kilobits per second.  The hello timer can be changed via the `hello_timer`.  The time is given in seconds, and the Quagga default is 10 seconds.  The dead timer can be changed via the `dead_timer`.  The time is given in seconds, and the Quagga default is 40 seconds.
 
 ## Dependencies
 

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -42,6 +42,7 @@ provisioner:
             - name: eth1
               bandwidth: 1000000
               hello_timer: 5
+              dead_timer: 20
   lint:
     name: ansible-lint
 scenario:

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -76,3 +76,10 @@ def test_ospfd_hello_timer_is_set(host):
             grep 'Timer intervals configured' | awk -F, '{print $2}'")
 
     assert hello_timer.stdout == " Hello 5s"
+
+
+def test_ospfd_dead_timer_is_set(host):
+    dead_timer = host.run("vtysh -c 'sh ip ospf int eth1' |\
+            grep 'Timer intervals configured' | awk -F, '{print $3}'")
+
+    assert dead_timer.stdout == " Dead 20s"

--- a/templates/ospfd.conf.j2
+++ b/templates/ospfd.conf.j2
@@ -7,9 +7,13 @@ hostname {{ inventory_hostname }}
 !
 {% if quagga_ospf.interfaces is defined %}
 {% for interface in quagga_ospf.interfaces %}
+!
 interface {{ interface.name }}
 {% if interface.hello_timer is defined %}
   ip ospf hello-interval {{ interface.hello_timer }}
+{% endif %}
+{% if interface.dead_timer is defined %}
+  ip ospf dead-interval {{ interface.dead_timer }}
 {% endif %}
 {% endfor %}
 {% endif %}


### PR DESCRIPTION
- Test written to validate that dead-interval timer is changed
- molecule.yml dead-interval variable added as dead_timer
- ospfd.conf.j2 structure added to insert dead-interval statement when
  variables is set.
- README updated to reflect the addition of the new variable for
  dead-interval