### PR TITLE
default-information originated added

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Only the zebdra daemon is eanbled by default within the role.  To enable ospfd s
 
     quagga_ospfd:
       router_id: 192.168.29.1
+      originate_default: true
       networks:
         - prefix: 192.168.29.0/24
           area: 0
@@ -32,7 +33,7 @@ Only the zebdra daemon is eanbled by default within the role.  To enable ospfd s
           hello_timer: 5
           dead_timer: 20
 
-The `quagga_ospfd` hash will contain the information needed configure OSPF on a host.  The `router_id` is the OSPF router-id for the host.
+The `quagga_ospfd` hash will contain the information needed configure OSPF on a host.  The `router_id` is the OSPF router-id for the host.  Optionally OSPF can originate a default route.  When `originate_default` is defined a default will be originated.  If you want a default even if there is no default in the route table you may set `originate_default` to always.
 
 The `networks` key contains a list of `prefix` and `area` that will be advertised via OSPF.  The interfaces matching the given prefix will have OSPF enabled on them.  OSPF will send out hello packets and form neighbor relationships over these interfaces.
 

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -31,6 +31,7 @@ provisioner:
       r1:
         quagga_ospf:
           router_id: 1.1.1.1
+          originate_default: true
           networks:
             - prefix: 192.168.29.0/24
               area: 0

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -83,3 +83,10 @@ def test_ospfd_dead_timer_is_set(host):
             grep 'Timer intervals configured' | awk -F, '{print $3}'")
 
     assert dead_timer.stdout == " Dead 20s"
+
+
+def test_osfpd_default_information_originate_is_set(host):
+    default_information = host.run("vtysh -c 'sh run' |\
+            grep 'default-information originate'")
+
+    assert default_information.stdout == ' default-information originate'

--- a/templates/ospfd.conf.j2
+++ b/templates/ospfd.conf.j2
@@ -23,6 +23,11 @@ router ospf
   log-adjacency-changes detail
   auto-cost reference-bandwidth {{ quagga_ospf_reference_bw }}
   ospf router-id {{ quagga_ospf.router_id }}
+  {% if quagga_ospf.originate_default is defined and quagga_ospf.originate_default == 'always' %}
+  default-information originate always
+  {% else %}
+  default-information originate
+  {% endif %}
   {% for network in quagga_ospf.networks %}
   network {{ network.prefix }} area {{ network.area }}
   {% endfor %}


### PR DESCRIPTION
molecule/default/molecule.yml
  Variable `originate_default` added and set to "true"

molecule/default/tests/test_default.pyc
  Test expects to find default-information originate in the ospfd.conf

templates/osfpd.conf.j2
  Logic added to handle default-information originate.  Logic also
  added to handle the always keyword.

README.md
 Documentation updated to show usage of the `originate_default` variable